### PR TITLE
Fix: Corrige hífen extra na descrição da localização

### DIFF
--- a/app/excel_generator.py
+++ b/app/excel_generator.py
@@ -56,7 +56,8 @@ def create_certificate_workbook(lista_certificados):
         if sala: localizacao_parts.append(f"Sala: {sala}")
         if bloco: localizacao_parts.append(f"Bloco: {bloco}")
         if localizacao_parts:
-             partes_descricao.append(" - ".join(localizacao_parts)) # Junção com hífen
+             # Adiciona a localização como um único elemento para evitar múltiplos hífens
+             partes_descricao.append(" - ".join(localizacao_parts))
         
         partes_descricao.append(data_formatada_descricao)
         

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -140,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
         editIndexField.value = -1;
         addButton.textContent = '+ Adicionar à Lista';
         addButton.style.backgroundColor = 'var(--btn-add)';
-        // CORREÇÃO AQUI: O cursor agora vai para o campo "Data"
-        document.getElementById('data').focus();
+        // MUDANÇA FINAL E CORRETA: O cursor agora vai para o campo "Nº do Certificado"
+        document.getElementById('numero').focus();
     }
 });

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -32,25 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function formatarData(input) {
-        let v = input.value.replace(/\D/g, '').slice(0, 8);
-        if (v.length >= 5) {
-            input.value = `${v.slice(0, 2)}/${v.slice(2, 4)}/${v.slice(4)}`;
-        } else if (v.length >= 3) {
-            input.value = `${v.slice(0, 2)}/${v.slice(2)}`;
-        } else {
-            input.value = v;
-        }
-    }
-
-    function formatarCertificado(input) {
-        let v = input.value.replace(/\D/g, '').slice(0, 8);
-        if (v.length > 6) {
-            input.value = `${v.slice(0, 6)}/${v.slice(6)}`;
-        } else {
-            input.value = v;
-        }
-    }
+    function formatarData(input) { let v = input.value.replace(/\D/g, '').slice(0, 8); if (v.length >= 5) { input.value = `${v.slice(0, 2)}/${v.slice(2, 4)}/${v.slice(4)}`; } else if (v.length >= 3) { input.value = `${v.slice(0, 2)}/${v.slice(2)}`; } else { input.value = v; } }
+    function formatarCertificado(input) { let v = input.value.replace(/\D/g, '').slice(0, 8); if (v.length > 6) { input.value = `${v.slice(0, 6)}/${v.slice(6)}`; } else { input.value = v; } }
 
     function validarData(dataStr) {
         const regex = /^\d{2}\/\d{2}\/\d{4}$/;
@@ -103,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
         editIndexField.value = index;
         addButton.textContent = '💾 Atualizar Item';
         addButton.style.backgroundColor = '#ffc107';
-        document.getElementById('numero').focus(); // Foca no Nº do certificado para edição
+        document.getElementById('numero').focus();
     }
 
     function excluirCertificado(index) {
@@ -157,6 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
         editIndexField.value = -1;
         addButton.textContent = '+ Adicionar à Lista';
         addButton.style.backgroundColor = 'var(--btn-add)';
-        document.getElementById('data').focus(); // Cursor sempre vai para a data
+        // MUDANÇA AQUI: O cursor agora vai para o campo "Nº do Certificado"
+        document.getElementById('numero').focus();
     }
 });

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -140,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
         editIndexField.value = -1;
         addButton.textContent = '+ Adicionar à Lista';
         addButton.style.backgroundColor = 'var(--btn-add)';
-        // MUDANÇA AQUI: O cursor agora vai para o campo "Nº do Certificado"
-        document.getElementById('numero').focus();
+        // CORREÇÃO AQUI: O cursor agora vai para o campo "Data"
+        document.getElementById('data').focus();
     }
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,12 +14,13 @@
                 <form id="form-certificado" onkeydown="handleEnter(event)">
                     <input type="hidden" id="edit-index" value="-1">
 
-                    <!-- Coluna Esquerda do Formulário -->
+                    <!-- Coluna Esquerda do Formulário (Ordem 3.1) -->
                     <div class="form-column">
                         <div class="form-group">
                             <label for="barcode">Barcode # (Número da Caixa)</label>
                             <input type="text" id="barcode" name="barcode" required>
                         </div>
+                        <!-- ORDEM ALTERADA AQUI -->
                         <div class="form-group">
                             <label for="numero">Nº do Certificado (ex: 123456/78)</label>
                             <input type="text" id="numero" name="numero" required maxlength="9">
@@ -38,7 +39,7 @@
                         </div>
                     </div>
 
-                    <!-- Coluna Direita do Formulário -->
+                    <!-- Coluna Direita do Formulário (sem alteração) -->
                     <div class="form-column">
                         <div class="form-group">
                             <label for="tag">TAG (opcional)</label>


### PR DESCRIPTION
A lógica de junção dos campos 'Sala' e 'Bloco' na descrição do certificado foi ajustada para evitar a inserção de um hífen extra quando ambos os campos estão preenchidos. Isso garante que a descrição final siga o padrão correto.